### PR TITLE
More flexible processor temperature parsing

### DIFF
--- a/MX-KoO/MX-Full
+++ b/MX-KoO/MX-Full
@@ -73,10 +73,10 @@ ${voffset -13}${alignr}${offset -60}${top_mem mem 4} %
 # CPU
 ${voffset -8}${font Open Sans:Bold:size=10}${color0}CPU ${color EC0100}${hr 3}
 $color${font}${execi 1000 cat /proc/cpuinfo | grep 'model name' | sed -e 's/model name.*: //'| uniq} ${freq_g cpu0}GHz $alignr $cpu%  
-${font}Core 0  ${color3}${execi 4 sensors | grep 'Core 0' | cut -c18-24} ${alignc 60}${color2}${cpubar cpu0}${color}
-${font}Core 1  ${color3}${execi 4 sensors | grep 'Core 1' | cut -c18-24} ${alignc 60}${color2}${cpubar cpu1}${color}
-${font}Core 2  ${color3}${execi 4 sensors | grep 'Core 2' | cut -c18-24} ${alignc 60}${color2}${cpubar cpu2}${color}
-${font}Core 3  ${color3}${execi 4 sensors | grep 'Core 3' | cut -c18-24} ${alignc 60}${color2}${cpubar cpu3}${color}
+${font}Core 0  ${color3}${execi 4 sensors | grep 'Core 0' | awk -F' ' '{print $3}' } ${alignc 60}${color2}${cpubar cpu0}${color}
+${font}Core 1  ${color3}${execi 4 sensors | grep 'Core 1' | awk -F' ' '{print $3}' } ${alignc 60}${color2}${cpubar cpu1}${color}
+${font}Core 2  ${color3}${execi 4 sensors | grep 'Core 2' | awk -F' ' '{print $3}' } ${alignc 60}${color2}${cpubar cpu2}${color}
+${font}Core 3  ${color3}${execi 4 sensors | grep 'Core 3' | awk -F' ' '{print $3}' } ${alignc 60}${color2}${cpubar cpu3}${color}
 
 ${voffset -10}------------------------------------------------- ${font Open Sans:Bold:size=10}${color0}${voffset -2}RAM${color}${font}${voffset -1} ---- ${font Open Sans:Bold:size=10}${color0}${voffset -2}CPU${color}${font}${voffset -1} -
 #${hr 1}


### PR DESCRIPTION
On some configurations, the temperature is displayed incorrectly due to a line hard split. This issue has been fixed here.